### PR TITLE
Restructure application into client and server directories

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,24 +24,13 @@
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
+    "extends": ["react-app", "react-app/jest"]
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
   },
-  "proxy": "http://localhost:5000",
+  "proxy": "http://localhost:3001",
   "devDependencies": {
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.32",

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,12 @@
+# Database Configuration
+DB_USER=sa
+DB_PASSWORD=your_password
+DB_SERVER=localhost
+DB_NAME=support_analytics
+
+# JWT Configuration
+JWT_SECRET=your_jwt_secret
+
+# Server Configuration
+PORT=3001
+NODE_ENV=development

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "support-analytics-server",
+  "version": "1.0.0",
+  "description": "Support Analytics Server",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "nodemon src/server.js"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "helmet": "^6.0.1",
+    "jsonwebtoken": "^9.0.0",
+    "mssql": "^9.1.1"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+require('dotenv').config();
+
+// Import routes
+const authRoutes = require('./api/routes/auth');
+const ticketRoutes = require('./api/routes/tickets');
+const analyticsRoutes = require('./api/routes/analytics');
+const metricsRoutes = require('./api/routes/metrics');
+
+// Import middleware
+const authMiddleware = require('./api/middleware/auth');
+
+const app = express();
+
+// Middleware
+app.use(helmet());
+app.use(cors());
+app.use(express.json());
+
+// Routes
+app.use('/api/auth', authRoutes);
+app.use('/api/tickets', authMiddleware, ticketRoutes);
+app.use('/api/analytics', authMiddleware, analyticsRoutes);
+app.use('/api/metrics', authMiddleware, metricsRoutes);
+
+// Error handling
+app.use((err, req, res, next) => {
+    console.error(err.stack);
+    res.status(500).json({ message: 'Something went wrong!' });
+});
+
+const PORT = process.env.PORT || 3001;
+
+app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
This PR reorganizes the repository structure to separate client and server code:

1. Server code is moved to `/server` directory
2. Client code is moved to `/client` directory
3. Updated package.json files for both client and server
4. Added proper .env.example files

To run the application:

1. Server setup:
```bash
cd server
npm install
cp .env.example .env
# Update .env with your database credentials
npm start
```

2. Client setup (in a new terminal):
```bash
cd client
npm install
npm start
```

The server will run on port 3001 and the client on port 3000.